### PR TITLE
Use optparse-clj for nice CLI options processing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :jar-exclusions [#"(?:\.(?:cljx|sw[onp])|cli\.cljs?)"]
-  :dependencies [[org.clojure/clojure "1.5.1"]]
+  :dependencies [[org.clojure/clojure "1.5.1"]
+                 [guns.cli/optparse "1.1.1"]]
   :plugins [[lein-cljsbuild "0.3.2"]
             [com.keminglabs/cljx "0.3.0"]]
   :source-paths ["src/cljx"]


### PR DESCRIPTION
Hello,

I wouldn't normally push my own project like this, but since you said you were interested in using optparse-clj… this is how I might implement it!

BTW, I resolved the issue with not seeing ARGV by adding the same externs file for process.js that you have in frak (thanks for figuring that one out). It's not in the jar, but I was just using it for testing.

I added a new option vector option to optparse-clj just for frak: the `:key` option allows customization of the resulting option key in order to translate `--exact` to `:exact? true`. It was a nice addition.

Anyway, thanks for the suggestion to port to CLJS. I've been wanting to delve into this aspect of CLJS for a while now.

Patch header:

Allows GNU style options clumping:

```
    $ bin/frak -ec foo bar baz
    ^(ba[rz]|foo)$
```

And nice failure messages:

```
    $ bin/frak foo bar baz --evil
    Failed to parse `--evil`: Invalid option
```
