### PR TITLE
Add missing escape

### DIFF
--- a/src/cljx/frak.cljx
+++ b/src/cljx/frak.cljx
@@ -139,7 +139,7 @@
      (if (and (:terminal? child)
               (not (seq (:children child))))
        (render-trie
-        (update-in child [:char] #(str % "?")) )
+        (update-in child [:char] #(str (escape %) "?")))
        (re-group (render-trie child) terminal?)))))
 
 (defmethod render-trie ::single-child-non-terminal

--- a/test/frak_test.clj
+++ b/test/frak_test.clj
@@ -59,6 +59,9 @@
   (is (= "b(?:i[pt]|at)"
          (string-pattern ["bat" "bip" "bit"] nil)))
 
+  (is (= "foo\\??"
+         (string-pattern ["foo" "foo?"])))
+
   (are [words] (every? #(re-matches (pattern words) %) words)
     ["achy" "achylia" "achylous" "achymia" "achymous"]
     ["aching" "achingly"]))


### PR DESCRIPTION
Hi @noprompt,

We're looking to expand usage of frak in vim-clojure-static and I found these two little bugs in the process.

BTW, would it be possible to either have access to escape-chars or provide a custom escape function? I'd like to be able to escape vim-specific special characters like `<`, `>`, `@`, and more. There are lots of ways to implement this (dynamic var, explicit parameter, callback, etc), so I didn't prepare a patch.

Thanks!
