### PR TITLE
Add whole-words? option for generated patterns to match only whole words

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .lein-failures
 .lein-plugins
 .lein-repl-history
+.nrepl-port

--- a/test/frak_test.clj
+++ b/test/frak_test.clj
@@ -5,8 +5,8 @@
 (def trie-put #'frak/trie-put)
 (def build-trie #'frak/build-trie)
 
-(deftest trie-test  
-  (is (= (build-trie ["a" "b"]) 
+(deftest trie-test
+  (is (= (build-trie ["a" "b"])
          {:char nil
           :terminal? false
           :children #{{:char \a
@@ -71,3 +71,15 @@
   (are [words] (every? #(re-matches (pattern words) %) words)
     ["achy" "achylia" "achylous" "achymia" "achymous"]
     ["aching" "achingly"]))
+
+(deftest pattern-whole-words
+  (is (= ["k pop"]
+         (re-seq (pattern ["pop" "k pop"]) "uk pop")))
+
+  (is (= ["k pop"]
+         (re-seq (pattern ["pop" "k pop"] {:whole-words? false}) "uk pop")))
+
+  (is (= ["uk" "pop" "rock"]
+         (re-seq (pattern ["pop" "k pop" "rock" "uk"] {:whole-words? true}) "uk pop and rock")))
+
+  (is (empty? (re-seq (pattern ["pop" "k pop"] {:whole-words? true}) "uk pops"))))


### PR DESCRIPTION
This option causes patterns to require a word boundary on either end of the match. For instance a pattern built like:

```clj
(frak/pattern ["foo" "bar" "baz"] {:whole-words? true})
```

Will create a match against the following strings:

    "foo is a metasyntactic variable"
    "sometimes we use baz"

but will not create a match against the following:

    "food and nutrition"
    "clubs and bars"