### PR TITLE
Cut over to just using .cljc and Clojure reader conditionals

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,35 +2,25 @@
   :description "Transform collections of strings into regular expressions."
   :url "http://github.com/noprompt/frak"
   :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+            :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :jar-exclusions [#"(?:\.(?:cljx|sw[onp])|cli\.cljs?)"]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "0.0-2156"]
                  [org.clojure/tools.cli "0.3.1"]]
-  :plugins [[lein-cljsbuild "1.0.2"]
-            [com.keminglabs/cljx "0.3.0"]]
-  :source-paths ["src/cljx"]
-  :profiles {:dev {:dependencies [[criterium "0.4.1"]
-                                  [com.keminglabs/cljx "0.3.0"]]
-                   :repl-options {:nrepl-middleware [cljx.repl-middleware/wrap-cljx]}
-                   :hooks [cljx.hooks]}}
-  :cljx {:builds [{:source-paths ["src/cljx"]
-                   :output-path "target/classes"
-                   :rules :clj}
-                  {:source-paths ["src/cljx"]
-                   :output-path "target/classes"
-                   :rules :cljs}]}
-  :cljsbuild {:builds [{:id "browser"
+  :plugins [[lein-cljsbuild "1.0.2"]]
+  :source-paths ["src/cljc"] 
+  :profiles {:dev {:dependencies [[criterium "0.4.1"]]}} 
+  :cljsbuild {:builds [{:id           "browser"
                         :source-paths ["target/classes"]
-                        :compiler {:output-to "target/js/frak.min.js"
-                                   :optimizations :advanced
-                                   :pretty-print false}}
-                       {:id "node"
+                        :compiler     {:output-to     "target/js/frak.min.js"
+                                       :optimizations :advanced
+                                       :pretty-print  false}}
+                       {:id           "node"
                         :source-paths ["target/classes"]
-                        :compiler {:output-to "bin/frak"
-                                   :externs ["resources/externs/process.js"]
-                                   :optimizations :advanced
-                                   :pretty-print false
-                                   :target :nodejs}}]}
+                        :compiler     {:output-to     "bin/frak"
+                                       :externs       ["resources/externs/process.js"]
+                                       :optimizations :advanced
+                                       :pretty-print  false
+                                       :target        :nodejs}}]}
   :main frak.cli
   :repl-options {:init-ns frak})

--- a/src/cljc/frak.cljc
+++ b/src/cljc/frak.cljc
@@ -202,7 +202,7 @@
   "Map lookup. In CLJS, also does lookup by string representation of kw."
   [map kw]
   (or (get map kw)
-      #+cljs (get map (name kw))))
+      #?(:cljs (get map (name kw)))))
 
 (def ^:private default-options
   {:capture? false
@@ -214,25 +214,24 @@
   "Construct a regular expression as a string from a collection
    of strings."
   ([strs]
-     (string-pattern strs default-options))
+   (string-pattern strs default-options))
   ([strs opts]
-     (let [#+cljs opts #+cljs (js->clj opts)
-           cs (or (get* opts :escape-chars) *escape-chars*)
-           cs (if (coll? cs) cs (get* metacharacters cs))
-           pattern (binding [*capture* (get* opts :capture?)
-                             *escape-chars* cs
-                             *whole-words* (get* opts :whole-words?)]
-                     (-> (build-trie strs)
-                         render-trie
-                         remove-unecessary-grouping))]
-       (if (get* opts :exact?)
-         (str "^" pattern "$")
-         (if (get* opts :whole-words?)
-           (str "\\b" pattern)
-           pattern)))))
+   (let [#?@(:cljs [opts (js->clj opts)])
+         cs      (or (get* opts :escape-chars) *escape-chars*)
+         cs      (if (coll? cs) cs (get* metacharacters cs))
+         pattern (binding [*capture*      (get* opts :capture?)
+                           *escape-chars* cs
+                           *whole-words*  (get* opts :whole-words?)]
+                   (-> (build-trie strs)
+                       render-trie
+                       remove-unecessary-grouping))]
+     (if (get* opts :exact?)
+       (str "^" pattern "$")
+       (if (get* opts :whole-words?)
+         (str "\\b" pattern)
+         pattern)))))
 
-#+cljs
-(def ^:export stringPattern string-pattern)
+#?(:cljs (def ^:export stringPattern string-pattern))
 
 (defn ^:export pattern
   "Construct a regular expression from a collection of strings."

--- a/src/cljc/frak/cli.cljc
+++ b/src/cljc/frak/cli.cljc
@@ -1,35 +1,10 @@
 (ns frak.cli
   "Command line interface."
   (:require [clojure.string :as string]
-            #+clj [clojure.tools.cli :refer [parse-opts]]
-            #+cljs [cljs.tools.cli :refer [parse-opts]]
-            [frak]))
-
-;;;; Utilities
-
-#+clj
-(defn exit [code]
-  (System/exit code))
-
-#+cljs 
-(defn exit [code]
-  (.exit js/process code))
-
-#+clj
-(defn printerr [message]
-  (.println *err* message))
-
-#+cljs
-(defn printerr [message]
-  (.error js/console message))
-
-#+clj
-(defn log [message]
-  (println message))
-
-#+cljs
-(defn log [message]
-  (.log js/console message))
+            #?(:clj  [clojure.tools.cli :refer [parse-opts]]
+               :cljs [cljs.tools.cli :refer [parse-opts]])
+            [frak]
+            [frak.plaform :refer [exit printerr log]]))
 
 ;;;; Main 
 
@@ -56,8 +31,8 @@
     (if (or (empty? words) (:help options))
       (log (str "Usage: frak <flags*> <strings+>\n\nFlags:\n" summary))
       (log (frak/string-pattern
-             words
-             (select-keys options [:exact? :capture? :escape-chars]))))
+            words
+            (select-keys options [:exact? :capture? :escape-chars]))))
     (exit 0)))
 
-#+cljs (set! *main-cli-fn* -main)
+#?(:cljs (set! *main-cli-fn* -main))

--- a/src/cljc/frak/platform.cljc
+++ b/src/cljc/frak/platform.cljc
@@ -1,0 +1,13 @@
+(ns frak.platform)
+
+(defn exit [code]
+  #?(:clj  (System/exit code)
+     :cljs (.exit js/process code)))
+
+(defn printerr [message]
+  #?(:clj  (.println *err* message)
+     :cljs (.error js/console message)))
+
+(defn log [message]
+  #?(:clj (println message)
+     :cljs (.log js/console message)))


### PR DESCRIPTION
With the introduction of reader conditionals, there isn't a particularly good reason to stay on the cljx ecosystem.

This changeset just cuts over from `.cljx` files to `.cljc` files, making use of reader conditionals where possible to maximize structural sharing between dialects.

Doesn't test cleanly on my machine due to the test case using textual rather than pattern structural equality on regexes.

```
running test task ["test"] ...

lein test frak-test

lein test :only frak-test/pattern-test

FAIL in (pattern-test) (frak_test.clj:59)
expected: (= "b(?:i[pt]|at)" (string-pattern ["bat" "bip" "bit"] nil))
  actual: (not (= "b(?:i[pt]|at)" "b(?:at|i[tp])"))
```