### PR TITLE
Avoid matching boundaries when pattern is empty

### DIFF
--- a/src/cljc/frak.cljc
+++ b/src/cljc/frak.cljc
@@ -122,7 +122,7 @@
      (re-char-set chars false))
   ([chars optional?]
      (when-let [chars (and (seq chars) (map escape chars))]
-       (str 
+       (str
         (if (= 1 (count chars))
           (first chars)
           (str \[ (apply str chars) \]))
@@ -167,7 +167,7 @@
   (let [groups (-> (juxt :terminal? :children)
                    (group-by children)
                    (dissoc nil))
-        subpatterns 
+        subpatterns
         (mapv
          (fn [[_ v]]
            (let [chars (map :char v)
@@ -227,7 +227,7 @@
                        remove-unecessary-grouping))]
      (if (get* opts :exact?)
        (str "^" pattern "$")
-       (if (get* opts :whole-words?)
+       (if (and (get* opts :whole-words?) (seq strs))
          (str "\\b" pattern)
          pattern)))))
 

--- a/test/frak_test.clj
+++ b/test/frak_test.clj
@@ -56,8 +56,8 @@
           #"ba\[[trz]{3}\]"
           (string-pattern ["bat" "bar" "baz"] nil))))
 
-  (is (= "b(?:i[pt]|at)"
-         (string-pattern ["bat" "bip" "bit"] nil)))
+  (let [p (string-pattern ["bat" "bip" "bit"] nil)]
+    (is (or (= "b(?:at|i[tp])" p) (= "b(?:i[pt]|at)" p)) p))
 
   (is (= "foo\\??"
          (string-pattern ["foo" "foo?"])))
@@ -73,6 +73,10 @@
     ["aching" "achingly"]))
 
 (deftest pattern-whole-words
+  (is (= ""
+         (string-pattern [] {:whole-words? false})
+         (string-pattern [] {:whole-words? true})))
+
   (is (= ["k pop"]
          (re-seq (pattern ["pop" "k pop"]) "uk pop")))
 


### PR DESCRIPTION
Hi Joel. This fixes a bug that relates to an edge case in the 'whole words' feature that I introduced last year.

When options include `{:whole-words? true}` and the strs are empty, the regex produced is `#"\b"` but it should be `#""`.